### PR TITLE
Fix CI build by updating Node version

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -14,7 +14,7 @@ LiveGraphs Static is a Next.js-based web application for visualizing chatbot con
 - **Charts**: Chart.js 4.5.0, React-ChartJS-2, Nivo
 - **Styling**: Tailwind CSS v4
 - **Package Manager**: pnpm v10
-- **Node Version**: 22.x (20.x also supported)
+- **Node Version**: 24.x (20.x also supported)
 - **Testing**: Vitest with React Testing Library
 - **Code Quality**: Biome (formatter/linter), ESLint, Husky, lint-staged
 

--- a/.github/CI-SETUP.md
+++ b/.github/CI-SETUP.md
@@ -11,7 +11,7 @@ This repository is configured with comprehensive GitHub Actions workflows and pr
 **Jobs:**
 
 - **Lint:** Runs ESLint, Biome checks, and format validation
-- **Test:** Matrix testing on Node.js 20.x and 22.x with coverage reporting
+- **Test:** Matrix testing on Node.js 20.x and 24.x with coverage reporting
 - **Build:** Validates production build
 - **Type Check:** TypeScript type validation
 - **Bundle Analysis:** Analyzes bundle size on pull requests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 env:
-  NODE_VERSION: '22.x'
+  NODE_VERSION: '24.x'
   PNPM_VERSION: '10'
 
 jobs:
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ['20.x', '22.x']
+        node-version: ['20.x', '24.x']
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -70,7 +70,7 @@ jobs:
         run: pnpm test:coverage
 
       - name: Upload coverage to Codecov
-        if: matrix.node-version == '22.x'
+        if: matrix.node-version == '24.x'
         uses: codecov/codecov-action@v4
         with:
           files: ./coverage/lcov.info

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 env:
-  NODE_VERSION: '22.x'
+  NODE_VERSION: '24.x'
   PNPM_VERSION: '10'
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ permissions:
   id-token: write
 
 env:
-  NODE_VERSION: '22.x'
+  NODE_VERSION: '24.x'
   PNPM_VERSION: '10'
 
 jobs:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
 
 env:
-  NODE_VERSION: '22.x'
+  NODE_VERSION: '24.x'
   PNPM_VERSION: '10'
 
 jobs:

--- a/lib/noopSqlJs.ts
+++ b/lib/noopSqlJs.ts
@@ -1,0 +1,3 @@
+export default async function initSqlJs() {
+  throw new Error("sql.js is not available in the Node.js environment");
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
@@ -23,8 +24,8 @@ const nextConfig: NextConfig = {
       ...config.resolve,
       alias: {
         ...config.resolve.alias,
-        // Always use the browser version of sql.js
-        "sql.js": "sql.js/dist/sql-wasm.js"
+        // Provide a noop module on the server
+        ...(isServer ? { "sql.js": path.resolve(__dirname, "lib/noopSqlJs.ts") } : {})
       },
       fallback: {
         ...config.resolve.fallback,
@@ -55,6 +56,12 @@ const nextConfig: NextConfig = {
         resourceRegExp: /^(fs|path|crypto|os|util|stream|buffer)$/
       })
     );
+
+    if (isServer) {
+      // Don't bundle sql.js for the server build
+      config.externals = config.externals || [];
+      config.externals.push("sql.js");
+    }
 
     if (!isServer) {
       // enable async WebAssembly in Webpack


### PR DESCRIPTION
## Summary
- bump Node.js version in CI workflow files
- note Node 24 in docs
- avoid bundling `sql.js` on the server

## Testing
- `pnpm lint`
- `pnpm lint:strict`
- `pnpm format:check`
- `pnpm tsc --noEmit`
- `pnpm test:coverage`
- `pnpm build` *(fails: Cannot read properties of undefined (reading 'module'))*

------
https://chatgpt.com/codex/tasks/task_e_687a68dd2a28832096bd905dcff1007e