### PR TITLE
Fix sql.js build errors

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -18,45 +18,43 @@ const nextConfig: NextConfig = {
   // Copy schema.sql to public directory during build,
   // enable WebAssembly support and force sql.js to its browser bundle
   webpack: (config, { isServer, webpack }) => {
-    // Configure module resolution
-    config.resolve = {
-      ...config.resolve,
-      alias: {
-        ...config.resolve.alias,
-        // Always use the browser version of sql.js
-        "sql.js": "sql.js/dist/sql-wasm.js"
-      },
-      fallback: {
-        ...config.resolve.fallback,
-        fs: false,
-        path: false,
-        crypto: false,
-        stream: false,
-        buffer: false,
-        util: false,
-        assert: false,
-        http: false,
-        https: false,
-        os: false,
-        url: false,
-        zlib: false,
-        http2: false,
-        net: false,
-        tls: false,
-        child_process: false,
-        worker_threads: false,
-        process: false
-      }
-    };
-
-    // Add ignore plugin to completely prevent bundling of Node.js modules
-    config.plugins.push(
-      new webpack.IgnorePlugin({
-        resourceRegExp: /^(fs|path|crypto|os|util|stream|buffer)$/
-      })
-    );
-
     if (!isServer) {
+      // Configure module resolution for browser environment
+      config.resolve = {
+        ...config.resolve,
+        alias: {
+          ...config.resolve.alias
+        },
+        fallback: {
+          ...config.resolve.fallback,
+          fs: false,
+          path: false,
+          crypto: false,
+          stream: false,
+          buffer: false,
+          util: false,
+          assert: false,
+          http: false,
+          https: false,
+          os: false,
+          url: false,
+          zlib: false,
+          http2: false,
+          net: false,
+          tls: false,
+          child_process: false,
+          worker_threads: false,
+          process: false
+        }
+      };
+
+      // Add ignore plugin to completely prevent bundling of Node.js modules
+      config.plugins.push(
+        new webpack.IgnorePlugin({
+          resourceRegExp: /^(fs|path|crypto|os|util|stream|buffer)$/
+        })
+      );
+
       // enable async WebAssembly in Webpack
       config.experiments = {
         ...config.experiments,

--- a/types/sqljs.d.ts
+++ b/types/sqljs.d.ts
@@ -1,0 +1,5 @@
+declare module "https://sql.js.org/dist/sql-wasm.js" {
+  import type initSqlJs from "sql.js";
+  const initSqlJsExport: typeof initSqlJs;
+  export default initSqlJsExport;
+}


### PR DESCRIPTION
## Summary
- load sql.js via CDN in browser to avoid bundling errors
- skip CDN import when running tests
- only disable Node core modules on client build
- add ambient type for CDN module

## Testing
- `pnpm build`
- `pnpm lint`
- `pnpm lint:strict`
- `pnpm format:check`
- `pnpm type-check`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_687a68dd2a28832096bd905dcff1007e